### PR TITLE
add create zk path exist judge

### DIFF
--- a/store/zk.go
+++ b/store/zk.go
@@ -92,7 +92,11 @@ func (z *Zookeeper) AddVolume(id int32, bfile, ifile string) (err error) {
 	var (
 		d     = fmt.Sprintf("%s,%s,%d", bfile, ifile, id)
 		dpath = path.Join(z.fpath, strconv.Itoa(int(id)))
+		exists bool
 	)
+	if exists, _, err = z.c.Exists(dpath); err == nil && exists {
+		return
+	}
 	if _, err = z.c.Create(dpath, []byte(d), 0, zk.WorldACL(zk.PermAll)); err != nil {
 		log.Errorf("zk.Create(\"%s\") error(%v)", dpath, err)
 		return


### PR DESCRIPTION
if not may result in 

```shell
E1028 23:07:47.672885   89295 zk.go:97] zk.Create("/rack/bfs-1/2") error(zk: node already exists)
E1028 23:07:47.673759   89295 store.go:259] zk.AddVolume(2) error(zk: node already exists)
```