### PR TITLE
修改由于BufferSize配置不正确，可能导致store刷index文件的时候挂掉

### DIFF
--- a/store/index/index.go
+++ b/store/index/index.go
@@ -111,7 +111,11 @@ func NewIndexer(file string, conf *conf.Config) (i *Indexer, err error) {
 	// must align size
 	i.ring = NewRing(conf.Index.RingBuffer)
 	i.bn = 0
-	i.buf = make([]byte, conf.Index.BufferSize)
+	if conf.Index.BufferSize < _indexSize {
+		i.buf = make([]byte, _indexSize)
+	} else {
+		i.buf = make([]byte, conf.Index.BufferSize)
+	}
 	if i.f, err = os.OpenFile(file, os.O_RDWR|os.O_CREATE|myos.O_NOATIME, 0664); err != nil {
 		log.Errorf("os.OpenFile(\"%s\") error(%v)", file, err)
 		return nil, err


### PR DESCRIPTION
如果BufferSize配置小于16，就会导致buf分配的buf的长度小于16，从而导致index刷盘的时候挂掉